### PR TITLE
EARTH-205 Fixed buttons for "Content Editor" text format to better ma…

### DIFF
--- a/config/install/editor.editor.content_editor.yml
+++ b/config/install/editor.editor.content_editor.yml
@@ -19,6 +19,11 @@ settings:
     rows:
       -
         -
+          name: style
+          items:
+            - Styles
+            - Format
+        -
           name: Formatting
           items:
             - Bold
@@ -45,12 +50,6 @@ settings:
             - DrupalFile
             - DrupalImage
             - Table
-            - HorizontalRule
-        -
-          name: style
-          items:
-            - Styles
-            - Format
         -
           name: Tools
           items:
@@ -58,6 +57,7 @@ settings:
             - Redo
             - ShowBlocks
             - Source
+            - PasteFromWord
         -
           name: Align
           items:

--- a/config/install/filter.format.content_editor.yml
+++ b/config/install/filter.format.content_editor.yml
@@ -28,7 +28,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <img alt title src aria-*> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a href hreflang data-entity-type data-entity-uuid title> <p style> <table> <tbody> <thead> <tr> <td colspan> <th colspan> <sub> <sup> <code> <pre> <span> <abbr> <div>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <img src alt height width data-entity-type data-entity-uuid data-align data-caption aria-*> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a href hreflang data-entity-type data-entity-uuid title> <p class style> <table> <tbody> <thead> <tr> <td colspan> <th colspan> <sub> <sup> <code> <pre> <span> <abbr> <div>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_url:

--- a/config/install/filter.format.content_editor.yml
+++ b/config/install/filter.format.content_editor.yml
@@ -28,7 +28,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <img src alt height width data-entity-type data-entity-uuid data-align data-caption aria-*> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a href hreflang data-entity-type data-entity-uuid title> <p class style> <table> <tbody> <thead> <tr> <td colspan> <th colspan> <sub> <sup> <code> <pre> <span> <abbr> <div>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <img src alt title height width data-* aria-*> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a href hreflang data-entity-type data-entity-uuid title> <p class style> <table> <tbody> <thead> <tr> <td colspan> <th colspan> <sub> <sup> <code> <pre> <span> <abbr> <div>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_url:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update WYSIWYG buttons for "Content Editor" text format to more closely match those in use by current Stanford Earth Drupal 7.x site.
- Fix "Limit allowed HTML tags" filter to allow image and styles button in WYSIWYG. 

# Needed By (Date)
- Next release.

# Urgency
- none

# Steps to Test

1. In your local installation (/WWW/se3_blt, for example), cd docroot/modules/stanford/stanford_text_editor
2. git fetch; git checkout EARTH-205
3. in browser, go to http://earth.local/admin/config/development/features/diff; import changes for stanford_text_editor
4. in browser, go to http://earth.local:8888/node/add/stanford_page
5. make sure Text format for WYSIWYG is set to "Content Editor"
6. WYSIWYG should show Styles and Format buttons first, and Styles should be enabled; image button and paste-from-word buttons should be present and enabled.

# Affected versions or modules

# Associated Issues and/or People

# See Also