### PR TITLE
D8CORE-1153: Remove h6 from format options.

### DIFF
--- a/config/install/filter.format.stanford_html.yml
+++ b/config/install/filter.format.stanford_html.yml
@@ -48,7 +48,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <h6 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes h6 from the options in the format bar in wysiwyg

# Review By (Date)
- Jan 29th

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Install site or import config (or manually edit the setting in the ui)
3. Clear cache
4. Review format drop down in wysiwyg editor on stanford_page wysiwyg component

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1153
- https://github.com/SU-SWS/stanford_profile/pull/70

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)