### PR TITLE
8.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Stanford Text Editor
 
+Version 8.x-1.3                                                       2020-02-21
+--------------------------------------------------------------------------------
+- Require later version of anchor_link module.
+- Updated ckeditor plugins for anchor link support.
+
 Version 8.x-1.2                                                       2020-02-14
 --------------------------------------------------------------------------------
 - Update stanford_html allowed_html list to have css classes on lists. (#15)

--- a/stanford_text_editor.info.yml
+++ b/stanford_text_editor.info.yml
@@ -9,5 +9,5 @@ dependencies:
   - drupal:filter
   - linkit:linkit
   - stanford_media:stanford_media
-version: 8.x-1.3-dev
+version: 8.x-1.3
 package: Stanford


### PR DESCRIPTION
```
# What
- Require later version of anchor_link module.
- Updated ckeditor plugins for anchor link support.

# So what
- Errors will not occur and we will be up to date on versions.

# Now what
- Deploy & Clear cache 

# New Requirements and Risks
- None
```