### PR TITLE
D8CORE-1792: Add a11y_checker plugin to editor.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ code_coverage: &code_coverage
         name: Run PHP Unit Coverage Tests
         command: |
           composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
-          ~/.composer/vendor/bin/sws-caravan phpunit /var/www/html --extension-dir=/var/www/test --with-coverage --latest-drupal
+          ~/.composer/vendor/bin/sws-caravan phpunit /var/www/html --extension-dir=/var/www/test --with-coverage
     - save_cache:
         key: dependencies-{{ epoch }}
         paths:
@@ -47,7 +47,7 @@ behat: &behat
         name: Run Behat Tests
         command: |
           composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
-          ~/.composer/vendor/bin/sws-caravan behat /var/www/html --extension-dir=/var/www/test --latest-drupal
+          ~/.composer/vendor/bin/sws-caravan behat /var/www/html --extension-dir=/var/www/test
     - save_cache:
         key: dependencies-{{ epoch }}
         paths:
@@ -67,12 +67,7 @@ jobs:
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
   version: 2
-  tests:
-    jobs:
-      - run-coverage
-      - run-behat
-  # Re-test every sunday in case this code becomes stale.
-  sundays:
+  weekly:
     jobs:
       - run-coverage
       - run-behat
@@ -83,3 +78,7 @@ workflows:
             branches:
               only:
                 - 8.x-1.x
+  tests:
+    jobs:
+      - run-coverage
+      - run-behat

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         }
     ],
     "require": {
-        "ckeditor-plugin/a11yhelp": "^4.14.0",
+        "ckeditor-plugin/a11ychecker": "^4.14.0",
         "ckeditor-plugin/balloonpanel": "^4.14.0",
         "ckeditor-plugin/fakeobjects": "^4.14.0",
         "ckeditor-plugin/link": "^4.14.0",

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,26 @@
         {
             "type": "package",
             "package": {
-                "name": "ckeditor-plugin/link",
-                "version": "4.13.1",
+                "name": "ckeditor-plugin/a11yhelp",
+                "version": "4.14.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/link/releases/link_4.13.1.zip",
+                    "url": "https://download.ckeditor.com/a11yhelp/releases/a11yhelp_4.14.0.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ckeditor-plugin/link",
+                "version": "4.14.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/link/releases/link_4.14.0.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -24,10 +39,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor-plugin/fakeobjects",
-                "version": "4.13.1",
+                "version": "4.10.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.13.1.zip",
+                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.14.0.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -37,8 +52,9 @@
         }
     ],
     "require": {
-        "ckeditor-plugin/fakeobjects": "^4.13.1",
-        "ckeditor-plugin/link": "^4.13.1",
+        "ckeditor-plugin/a11yhelp": "^4.14.0",
+        "ckeditor-plugin/fakeobjects": "^4.14.0",
+        "ckeditor-plugin/link": "^4.14.0",
         "composer/installers": "^1.2",
         "drupal/anchor_link": "^2.2",
         "drupal/core": "^8.8",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
                 "version": "4.14.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/a11yhelp/releases/balloonpanel_4.14.0.zip",
+                    "url": "https://download.ckeditor.com/balloonpanel/releases/balloonpanel_4.14.0.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
             "type": "package",
             "package": {
                 "name": "ckeditor-plugin/fakeobjects",
-                "version": "4.10.0",
+                "version": "4.14.0",
                 "type": "drupal-library",
                 "dist": {
                     "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.14.0.zip",
@@ -68,7 +68,7 @@
     ],
     "require": {
         "ckeditor-plugin/a11yhelp": "^4.14.0",
-        "ckeditor-plugin/balloonpanel": "^4.4.0",
+        "ckeditor-plugin/balloonpanel": "^4.14.0",
         "ckeditor-plugin/fakeobjects": "^4.14.0",
         "ckeditor-plugin/link": "^4.14.0",
         "composer/installers": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,21 @@
         {
             "type": "package",
             "package": {
+                "name": "ckeditor-plugin/balloonpanel",
+                "version": "4.14.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/a11yhelp/releases/balloonpanel_4.14.0.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
                 "name": "ckeditor-plugin/link",
                 "version": "4.14.0",
                 "type": "drupal-library",
@@ -53,10 +68,12 @@
     ],
     "require": {
         "ckeditor-plugin/a11yhelp": "^4.14.0",
+        "ckeditor-plugin/balloonpanel" "^4.4.0",
         "ckeditor-plugin/fakeobjects": "^4.14.0",
         "ckeditor-plugin/link": "^4.14.0",
         "composer/installers": "^1.2",
         "drupal/anchor_link": "^2.2",
+        "drupal/ckeditor_a11ychecker": "^1.0",
         "drupal/core": "^8.8",
         "drupal/editor_advanced_link": "^1.4",
         "drupal/embed": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor-plugin/a11ychecker",
-                "version": "4.14.0",
+                "version": "1.1.1",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/a11ychecker/releases/a11ychecker_4.14.0.zip",
+                    "url": "https://download.ckeditor.com/a11ychecker/releases/a11ychecker_1.1.1.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -67,7 +67,7 @@
         }
     ],
     "require": {
-        "ckeditor-plugin/a11ychecker": "^4.14.0",
+        "ckeditor-plugin/a11ychecker": "^1.1.1",
         "ckeditor-plugin/balloonpanel": "^4.14.0",
         "ckeditor-plugin/fakeobjects": "^4.14.0",
         "ckeditor-plugin/link": "^4.14.0",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     ],
     "require": {
         "ckeditor-plugin/a11yhelp": "^4.14.0",
-        "ckeditor-plugin/balloonpanel" "^4.4.0",
+        "ckeditor-plugin/balloonpanel": "^4.4.0",
         "ckeditor-plugin/fakeobjects": "^4.14.0",
         "ckeditor-plugin/link": "^4.14.0",
         "composer/installers": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         {
             "type": "package",
             "package": {
-                "name": "ckeditor-plugin/a11yhelp",
+                "name": "ckeditor-plugin/a11ychecker",
                 "version": "4.14.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/a11yhelp/releases/a11yhelp_4.14.0.zip",
+                    "url": "https://download.ckeditor.com/a11ychecker/releases/a11ychecker_4.14.0.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/config/install/editor.editor.stanford_html.yml
+++ b/config/install/editor.editor.stanford_html.yml
@@ -51,6 +51,8 @@ settings:
             - RemoveFormat
             - Source
             - PasteFromWord
+            - '-'
+            - A11ychecker
   plugins:
     stylescombo:
       styles: "a.su-button|Button\r\na.su-button--big|Big Button\r\na.su-button--secondary|Secondary Button\r\na.su-link--action|Action Link\r\np.plain-text|Normal\r\np.su-intro-text|Intro Text\r\np.su-font-splash|Splash Font\r\np.su-quote-text|Quote Text\r\np.su-drop-cap|Drop Cap First Letter\r\np.su-related-text|Card Text\r\np.su-callout-text|Callout Text\r\np.su-subheading|Sub Title"

--- a/stanford_text_editor.info.yml
+++ b/stanford_text_editor.info.yml
@@ -7,6 +7,8 @@ dependencies:
   - drupal:ckeditor
   - drupal:editor
   - drupal:filter
+  - ckeditor_a11ychecker:ckeditor_a11ychecker
+  - ckeditor_a11ychecker:ckeditor_balloonpanel
   - linkit:linkit
   - stanford_media:stanford_media
 version: 8.x-1.5-dev

--- a/tests/behat/features/WYSIWYGButtons.feature
+++ b/tests/behat/features/WYSIWYGButtons.feature
@@ -10,7 +10,7 @@ Feature: WYSIWYG Buttons
     Then I am on "/node/add/page"
     And I select "HTML" from "Text format"
     And I wait 1 seconds
-    Then I should see 21 "a.cke_button" elements
+    Then I should see 22 "a.cke_button" elements
 
     Then I should see 1 "a.cke_button[title='Bold (Ctrl+B)']" elements
     Then I should see 1 "a.cke_button[title='Italic (Ctrl+I)']" elements

--- a/tests/behat/features/WYSIWYGButtons.feature
+++ b/tests/behat/features/WYSIWYGButtons.feature
@@ -33,6 +33,7 @@ Feature: WYSIWYG Buttons
     Then I should see 1 "a.cke_button[title='Remove Format']" elements
     Then I should see 1 "a.cke_button[title='Source']" elements
     Then I should see 1 "a.cke_button[title='Paste from Word']" elements
+    Then I should see 1 "a.cke_button__a11ychecker" elements
 
     And I fill in "Title" with "Test autocomplete"
     And I press "Save"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds the accessibility checker plugin to stanford_html formats

# Review By (Date)
- April 7th

# Urgency
- Low

# Steps to Test

1. See: https://github.com/SU-SWS/acsf-cardinalsites/pull/134
2. Review code.

# Affected Projects or Products
- D8CORE-1792

# Associated Issues and/or People
- D8CORE-1792

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
