### PR TITLE
Added ckeditor fixed toolbar plugin

### DIFF
--- a/js/plugins/fixed_toolbar/plugin.js
+++ b/js/plugins/fixed_toolbar/plugin.js
@@ -1,0 +1,16 @@
+CKEDITOR.plugins.add('fixed_toolbar', {
+  init: (editor) => {
+    CKEDITOR.on('instanceReady', (e) => {
+      if (null === e.editor.container.find('.cke_top').getItem(0)) {
+        return;
+      }
+      const toolBar = e.editor.container.find('.cke_top').getItem(0).$;
+      toolBar.style.position = 'sticky';
+
+      const dialog = jQuery('.MuiDialogTitle-root');
+      // We use the same offset as Drupal uses for body to make up for Admin
+      // Toolbar.
+      toolBar.style.top = document.body.style.paddingTop;
+    });
+  },
+});

--- a/src/Plugin/CKEditorPlugin/FixedToolbar.php
+++ b/src/Plugin/CKEditorPlugin/FixedToolbar.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\stanford_text_editor\Plugin\CKEditorPlugin;
+
+use Drupal\ckeditor\CKEditorPluginBase;
+use Drupal\ckeditor\CKEditorPluginContextualInterface;
+use Drupal\editor\Entity\Editor;
+
+/**
+ * Defines the "fixed_toolbar" plugin.
+ *
+ * @CKEditorPlugin(
+ *   id = "fixed_toolbar",
+ *   label = @Translation("Fixed Toolbar"),
+ *   module = "ckeditor_fixed_toolbar"
+ * )
+ */
+class FixedToolbar extends CKEditorPluginBase implements CKEditorPluginContextualInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFile() {
+    return drupal_get_path('module', 'stanford_text_editor') . '/js/plugins/fixed_toolbar/plugin.js';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLibraries(Editor $editor) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig(Editor $editor) {
+    return [];
+  }
+
+  /**
+   * Returns the buttons that this plugin provides, along with metadata.
+   *
+   * The metadata is used by the CKEditor module to generate a visual CKEditor
+   * toolbar builder UI.
+   *
+   * @return array
+   *   An array of buttons that are provided by this plugin. This will
+   *   only be used in the administrative section for assembling the toolbar.
+   *   Each button should be keyed by its CKEditor button name (you can look up
+   *   the button name up in the plugin.js file), and should contain an array of
+   *   button properties, including:
+   *   - label: A human-readable, translated button name.
+   *   - image: An image for the button to be used in the toolbar.
+   *   - image_rtl: If the image needs to have a right-to-left version, specify
+   *     an alternative file that will be used in RTL editors.
+   *   - image_alternative: If this button does not render as an image, specify
+   *     an HTML string representing the contents of this button.
+   *   - image_alternative_rtl: Similar to image_alternative, but a
+   *     right-to-left version.
+   *   - attributes: An array of HTML attributes which should be added to this
+   *     button when rendering the button in the administrative section for
+   *     assembling the toolbar.
+   *   - multiple: Boolean value indicating if this button may be added multiple
+   *     times to the toolbar. This typically is only applicable for dividers
+   *     and group indicators.
+   */
+  public function getButtons() {
+    return [];
+  }
+
+  /**
+   * Checks if this plugin should be enabled based on the editor configuration.
+   *
+   * The editor's settings can be retrieved via $editor->getSettings().
+   *
+   * @param \Drupal\editor\Entity\Editor $editor
+   *   A configured text editor object.
+   *
+   * @return bool
+   *   Return TRUE when this plugin is enabled.
+   */
+  public function isEnabled(Editor $editor) {
+    return TRUE;
+  }
+
+}

--- a/tests/src/Kernel/Plugin/CKEditorPlugin/FixedToolbarTest.php
+++ b/tests/src/Kernel/Plugin/CKEditorPlugin/FixedToolbarTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\stanford_text_editor\Kernel\Plugin\CkeditorPlugin;
+
+use Drupal\editor\Entity\Editor;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Class FixedToolbarTest
+ *
+ * @group stanford_text_editor
+ */
+class FixedToolbarTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'ckeditor', 'stanford_text_editor'];
+
+  /**
+   * Fixed toolbar plugin exists.
+   */
+  public function testFixedToolbarPlugin() {
+    /** @var \Drupal\ckeditor\CKEditorPluginManager $ckeditor_plugin_manager */
+    $ckeditor_plugin_manager = \Drupal::service('plugin.manager.ckeditor.plugin');
+    $this->assertArrayHasKey('fixed_toolbar', $ckeditor_plugin_manager->getDefinitions());
+    /** @var \Drupal\stanford_text_editor\Plugin\CKEditorPlugin\FixedToolbar $plugin */
+    $plugin = $ckeditor_plugin_manager->createInstance('fixed_toolbar');
+    $this->assertStringContainsString('plugin.js', $plugin->getFile());
+
+    $editor = $this->createMock(Editor::class);
+
+    $this->assertEmpty($plugin->getLibraries($editor));
+    $this->assertEmpty($plugin->getConfig($editor));
+    $this->assertEmpty($plugin->getButtons($editor));
+    $this->assertTrue($plugin->isEnabled($editor));
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added ckeditor plugin to make the toolbar sticky when scrolling.

# Need Review By (Date)
- 12/3

# Urgency
- low

# Steps to Test
1. checkout this branch
1. ensure `ckeditor_fixed_toolbar` isn't enabled
1. clear cached
1. view a node without react paragraphs
1. verify the wysiwyg toolbar is sticky when scrolling.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
